### PR TITLE
Add links to github repo in extension labels for marketplace

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,10 @@ LABEL org.opencontainers.image.title="RabbitMQ" \
     com.docker.extension.screenshots="[{\"alt\":\"RabbitMQ Dashboard\", \"url\":\"https://raw.githubusercontent.com/Yogendra0Sharma/docker-extension-rabbitmq/main/screenshots.png\"}]"  \
     com.docker.extension.detailed-description="This Extension helps RabbitMQ developers to run RabbitMQ Management Dashboard as a single-click installation using RabbitMQ Docker Extension" \
     com.docker.extension.publisher-url="https://github.com/Yogendra0Sharma/docker-extension-RabbitMQ" \
-    com.docker.extension.additional-urls="" \
+    com.docker.extension.additional-urls="[ \
+    {\"title\":\"Github repo\", \"url\":\"https://github.com/Yogendra0Sharma/docker-extension-rabbitmq\"}, \
+    {\"title\":\"Report issues\", \"url\":\"https://github.com/Yogendra0Sharma/docker-extension-rabbitmq/issues\"} \
+    ]" \
     com.docker.extension.changelog=""
 
 COPY docker-compose.yaml .


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

Add links displayed in the marketplace detail card for the extension